### PR TITLE
feat(eslint-config-ts): enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/packages/eslint-config-ts/.eslintrc.json
+++ b/packages/eslint-config-ts/.eslintrc.json
@@ -15,6 +15,7 @@
   "plugins": ["sort-destructure-keys"],
   "rules": {
     "@typescript-eslint/camelcase": "off", // c.f. https://github.com/typescript-eslint/typescript-eslint/issues/2050
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/explicit-function-return-type": [
       "error",
       {


### PR DESCRIPTION
通常のimportとtype-only importが混在していると読みづらいので、使い分けを強制するルールを有効化する。（import部分を読むことは少ないが。）

このルールはfixにも対応しているので、入れるデメリットは無いと考えている。
