### PR TITLE
fix: apply minimum release age to pip dependencies


### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,7 +19,7 @@
   dependencyDashboardAutoclose: true,
   packageRules: [
     {
-      matchDatasources: ['npm'],
+      matchDatasources: ['npm', 'pypi'],
       minimumReleaseAge: '5 days',
     },
     {


### PR DESCRIPTION
## Summary

- Apply the 5-day `minimumReleaseAge` Renovate rule to both `npm` and `pypi` datasources
- Keep the later npm-only preapproved-package exception unchanged
- Limit the change to the shared top-level package rule in `renovate.json5`

## Why

- The existing rule only delayed npm updates, so Python package updates were not covered by the same release-age guardrail
- Extending the shared rule is the smallest change that preserves the existing exception behavior for approved npm packages

## Testing

- `yarn check-for-ai`

## Notes

- CI is currently passing and there are no unresolved review threads
- No linked issue was provided
