### PR TITLE
fix: allow latest agent-runtime-kit updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -169,7 +169,15 @@
     {
       description: 'Allow immediate updates for preapproved npm packages',
       matchDatasources: ['npm'],
-      matchPackageNames: ['/^@exercode\\//', '/^@willbooster\\//', 'next', '/^@next\\//', 'react', 'react-dom'],
+      matchPackageNames: [
+        '/^@exercode\\//',
+        '/^@willbooster\\//',
+        'agent-runtime-kit',
+        'next',
+        '/^@next\\//',
+        'react',
+        'react-dom',
+      ],
       minimumReleaseAge: '0 days',
     },
     {


### PR DESCRIPTION
## Summary
- allow Renovate to update agent-runtime-kit immediately by adding it to the preapproved npm package list

## Verification
- yarn check-for-ai