### PR TITLE
fix: avoid workspace protocol in release metadata

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,7 +25,7 @@
     "@types/eslint": "9.6.1",
     "@types/micromatch": "4.0.10",
     "@types/node": "25.5.2",
-    "@willbooster/eslint-config-ts": "workspace:^",
+    "@willbooster/eslint-config-ts": "0.0.0-semantically-released",
     "@willbooster/prettier-config": "^10.4.0",
     "eslint": "^10.2.0",
     "eslint-config-flat-gitignore": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,7 +2145,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@willbooster/eslint-config-ts@workspace:^, @willbooster/eslint-config-ts@workspace:packages/eslint-config-ts":
+"@willbooster/eslint-config-ts@npm:0.0.0-semantically-released, @willbooster/eslint-config-ts@workspace:packages/eslint-config-ts":
   version: 0.0.0-use.local
   resolution: "@willbooster/eslint-config-ts@workspace:packages/eslint-config-ts"
   dependencies:
@@ -2248,7 +2248,7 @@ __metadata:
     "@types/eslint": "npm:9.6.1"
     "@types/micromatch": "npm:4.0.10"
     "@types/node": "npm:25.5.2"
-    "@willbooster/eslint-config-ts": "workspace:^"
+    "@willbooster/eslint-config-ts": "npm:0.0.0-semantically-released"
     "@willbooster/prettier-config": "npm:^10.4.0"
     eslint: "npm:^10.2.0"
     eslint-config-flat-gitignore: "npm:2.3.0"


### PR DESCRIPTION
## Summary

- Replace the private shared package's workspace protocol dependency with the local placeholder semver version.
- Update the Yarn lockfile so Yarn still resolves @willbooster/eslint-config-ts to the local workspace.

## Why

- The release job failed because @semantic-release/npm runs npm version inside the workspace, and npm rejects workspace:^ dependency ranges.
- Using the existing placeholder semver version keeps the dependency valid for npm while preserving local Yarn workspace resolution.

## Testing

- npm version 4.0.0 --userconfig /tmp/willbooster-configs-release-test.npmrc --no-git-tag-version --allow-same-version --dry-run --workspace @willbooster/biome-config (in a temporary copy)
- corepack yarn install --immutable
- corepack yarn check-for-ai
- bunx @willbooster/agent-skills@latest check-pr-ci
