### PR TITLE
fix: avoid private workspace release edge

### DIFF
--- a/packages/shared/eslint.config.js
+++ b/packages/shared/eslint.config.js
@@ -1,1 +1,1 @@
-export { default } from '@willbooster/eslint-config-ts';
+export { default } from '../eslint-config-ts/eslint.config.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,7 +25,6 @@
     "@types/eslint": "9.6.1",
     "@types/micromatch": "4.0.10",
     "@types/node": "25.5.2",
-    "@willbooster/eslint-config-ts": "0.0.0-semantically-released",
     "@willbooster/prettier-config": "^10.4.0",
     "eslint": "^10.2.0",
     "eslint-config-flat-gitignore": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,7 +2145,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@willbooster/eslint-config-ts@npm:0.0.0-semantically-released, @willbooster/eslint-config-ts@workspace:packages/eslint-config-ts":
+"@willbooster/eslint-config-ts@workspace:packages/eslint-config-ts":
   version: 0.0.0-use.local
   resolution: "@willbooster/eslint-config-ts@workspace:packages/eslint-config-ts"
   dependencies:
@@ -2248,7 +2248,6 @@ __metadata:
     "@types/eslint": "npm:9.6.1"
     "@types/micromatch": "npm:4.0.10"
     "@types/node": "npm:25.5.2"
-    "@willbooster/eslint-config-ts": "npm:0.0.0-semantically-released"
     "@willbooster/prettier-config": "npm:^10.4.0"
     eslint: "npm:^10.2.0"
     eslint-config-flat-gitignore: "npm:2.3.0"


### PR DESCRIPTION
## Summary
- remove the private shared package dependency on @willbooster/eslint-config-ts
- import the local TypeScript ESLint config by relative path for shared package linting
- update the Yarn lockfile to remove the extra npm alias for @willbooster/eslint-config-ts

## Why
- The release job failed when @semantic-release/npm ran npm version 12.0.0 in packages/eslint-config-ts.
- npm 11 crashes in Arborist workspace link resolution when the private shared workspace depends back on the workspace package being versioned.
- The shared package only needs the config for local linting, so a relative config import avoids the npm workspace dependency edge while keeping local lint behavior on the in-repo config.

## Testing
- npm version 12.0.0 --userconfig /tmp/willbooster-configs-release-test.npmrc --no-git-tag-version --allow-same-version --dry-run (in packages/eslint-config-ts inside a temporary copy)
- corepack yarn check-for-ai