### PR TITLE
feat: enable oxlint type checking

### DIFF
--- a/packages/eslint-config-ts-react/tsconfig.json
+++ b/packages/eslint-config-ts-react/tsconfig.json
@@ -12,6 +12,7 @@
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
+    "rootDir": ".",
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,

--- a/packages/eslint-config-ts/tsconfig.json
+++ b/packages/eslint-config-ts/tsconfig.json
@@ -11,6 +11,7 @@
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
+    "rootDir": ".",
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,

--- a/packages/oxlint-config/.oxlintrc.json
+++ b/packages/oxlint-config/.oxlintrc.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["eslint", "import", "jsx-a11y", "oxc", "promise", "react", "react-perf", "typescript", "unicorn"],
   "options": {
-    "typeAware": true
+    "typeAware": true,
+    "typeCheck": true
   },
   "env": {
     "builtin": true,

--- a/packages/oxlint-config/.oxlintrc.json
+++ b/packages/oxlint-config/.oxlintrc.json
@@ -121,7 +121,7 @@
     "react/no-unescaped-entities": "error",
     "react/no-unknown-property": "error",
     "react/no-unsafe": "off",
-    "react/react-in-jsx-scope": "error",
+    "react/react-in-jsx-scope": "off",
     "react/require-render-return": "error",
     "unicorn/catch-error-name": "error",
     "unicorn/consistent-assert": "error",

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -23,3 +23,9 @@ Run Oxlint as usual.
 ```sh
 oxlint .
 ```
+
+To debug this shared config from this repository, run it against the local fixture project.
+
+```sh
+npx -y -p oxlint@1.60.0 -p oxlint-tsgolint@0.18.1 oxlint --type-aware --type-check -c packages/oxlint-config/.oxlintrc.json packages/oxlint-config
+```

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -1,7 +1,7 @@
 # oxlint-config
 
 An Oxlint config for WillBooster projects.
-This config follows the latest Oxlint config model and enables type-aware TypeScript rules by default, so `oxlint-tsgolint` is required together with `oxlint`.
+This config follows the latest Oxlint config model and enables type-aware TypeScript rules and type-checking diagnostics by default, so `oxlint-tsgolint` is required together with `oxlint`.
 It also enables Oxlint's built-in React, React performance, JSX accessibility, and Promise plugins to cover projects that otherwise use `@willbooster/eslint-config-ts-react`.
 
 Install the package and its peer dependencies.

--- a/packages/oxlint-config/test/component.jsx
+++ b/packages/oxlint-config/test/component.jsx
@@ -1,0 +1,3 @@
+export function DebugComponent() {
+  return <button type="button">Debug oxlint</button>;
+}

--- a/packages/oxlint-config/test/typeAware.mts
+++ b/packages/oxlint-config/test/typeAware.mts
@@ -1,0 +1,15 @@
+interface DebugResult {
+  readonly message: string;
+}
+
+export async function loadDebugResult(): Promise<DebugResult> {
+  return {
+    message: 'debug oxlint',
+  };
+}
+
+export async function logDebugResult(): Promise<void> {
+  const result = await loadDebugResult();
+
+  console.log(result.message);
+}

--- a/packages/oxlint-config/tsconfig.json
+++ b/packages/oxlint-config/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
+    "declaration": true,
+    "erasableSyntaxOnly": true,
+    "esModuleInterop": true,
+    "importHelpers": false,
+    "jsx": "react-jsx",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "esnext",
+    "typeRoots": ["../../node_modules/@types", "../../@types", "./@types"],
+    "types": ["node"]
+  },
+  "exclude": ["test/fixtures"],
+  "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
+  "include": ["test/**/*"]
+}


### PR DESCRIPTION
## Summary
- Enable Oxlint type-checking diagnostics alongside existing type-aware linting.
- Disable the classic React-in-JSX-scope rule for automatic JSX runtime projects.
- Add explicit rootDir values for test-only TypeScript config packages so Oxlint type-check diagnostics can load their tsconfigs cleanly.
- Add a local tsconfig and debug fixtures to packages/oxlint-config so the shared config can be verified directly.
- Update the oxlint config README to document type-checking diagnostics and the local debug command.

## Verification
- npx -y -p oxlint@1.60.0 -p oxlint-tsgolint@0.18.1 oxlint --type-aware --type-check -c packages/oxlint-config/.oxlintrc.json packages/oxlint-config
- npx -y -p oxlint@1.60.0 -p oxlint-tsgolint@0.18.1 oxlint --type-aware --type-check -c packages/oxlint-config/.oxlintrc.json packages
- yarn check-for-ai