### PR TITLE
fix: remove unsupported oxlint unicorn rule

### DIFF
--- a/packages/oxlint-config/config.mjs
+++ b/packages/oxlint-config/config.mjs
@@ -140,7 +140,6 @@ const config = {
     'unicorn/consistent-empty-array-spread': 'error',
     'unicorn/consistent-existence-index-check': 'error',
     'unicorn/consistent-function-scoping': 'error',
-    'unicorn/consistent-template-literal-escape': 'error',
     'unicorn/empty-brace-spaces': 'error',
     'unicorn/error-message': 'error',
     'unicorn/escape-case': 'error',


### PR DESCRIPTION
## Summary

- Removed `unicorn/consistent-template-literal-escape` from `@willbooster/oxlint-config`.

## Why

- Local cross-repo search showed this rule is configured in `willbooster-configs` and worked around in `wbfy` by deleting it from generated configs.
- Oxlint does not currently ship this Unicorn rule, so the shared config should not enable it across projects.

## Testing

- `yarn check-for-ai`
- Pre-commit hook completed
- Pre-push hook completed
