### PR TITLE
fix: allow Next instrumentation client filename

### DIFF
--- a/packages/oxlint-config/config.mjs
+++ b/packages/oxlint-config/config.mjs
@@ -283,6 +283,7 @@ const config = {
     {
       files: [
         '**/app/**/{global-error,not-found}.{js,jsx,ts,tsx}',
+        '**/instrumentation-client.{js,jsx,ts,tsx}',
         '**/pages/{_app,_document,_error,404,500}.{js,jsx,ts,tsx}',
       ],
       rules: {


### PR DESCRIPTION
## Summary

- Added Next.js `instrumentation-client` to the Oxlint filename-case override for reserved framework filenames.
- Keeps `unicorn/filename-case` enabled for normal project files while avoiding false positives for a file name Next.js requires.

## Why

- Projects using `@willbooster/oxlint-config` should not need local disables for Next.js reserved filenames.
- `instrumentation-client.ts` cannot be renamed to camelCase or PascalCase without breaking Next.js convention.

## Testing

- yarn check-for-ai
- Validated against exercode with: `oxlint src/instrumentation-client.ts --config /Users/exkazuu/ghq/github.com/WillBooster/willbooster-configs/packages/oxlint-config/config.mjs`
