### PR TITLE
fix: improve shared config typings

### DIFF
--- a/packages/eslint-config-js-react/eslint.config.d.ts
+++ b/packages/eslint-config-js-react/eslint.config.d.ts
@@ -1,0 +1,5 @@
+import type { Linter } from 'eslint';
+
+declare const config: Linter.Config[];
+
+export default config;

--- a/packages/eslint-config-js-react/package.json
+++ b/packages/eslint-config-js-react/package.json
@@ -2,21 +2,20 @@
   "name": "@willbooster/eslint-config-js-react",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for JavaScript React projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-js-react"
   },
-  "files": [
-    "eslint.config.js"
-  ],
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "type": "module",
   "main": "eslint.config.js",
-  "publishConfig": {
-    "access": "public"
-  },
+  "types": "eslint.config.d.ts",
+  "files": [
+    "eslint.config.d.ts",
+    "eslint.config.js"
+  ],
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -28,6 +27,7 @@
     "prettify": "prettier --cache --color --no-error-on-unmatched-pattern --write \"**/{.*/,}*.{java}\" \"!**/test{-,/}fixtures/**\" || true",
     "test": "yarn lint"
   },
+  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint-react/eslint-plugin": "4.2.3",
     "@eslint/js": "10.0.1",
@@ -70,5 +70,7 @@
     "globals": ">=16",
     "typescript": ">=5"
   },
-  "prettier": "@willbooster/prettier-config"
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/eslint-config-js-react/package.json
+++ b/packages/eslint-config-js-react/package.json
@@ -2,20 +2,23 @@
   "name": "@willbooster/eslint-config-js-react",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for JavaScript React projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-js-react"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -27,7 +30,6 @@
     "prettify": "prettier --cache --color --no-error-on-unmatched-pattern --write \"**/{.*/,}*.{java}\" \"!**/test{-,/}fixtures/**\" || true",
     "test": "yarn lint"
   },
-  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint-react/eslint-plugin": "4.2.3",
     "@eslint/js": "10.0.1",
@@ -70,7 +72,5 @@
     "globals": ">=16",
     "typescript": ">=5"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "prettier": "@willbooster/prettier-config"
 }

--- a/packages/eslint-config-js/eslint.config.d.ts
+++ b/packages/eslint-config-js/eslint.config.d.ts
@@ -1,0 +1,5 @@
+import type { Linter } from 'eslint';
+
+declare const config: Linter.Config[];
+
+export default config;

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -2,20 +2,23 @@
   "name": "@willbooster/eslint-config-js",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for JavaScript projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-js"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -27,7 +30,6 @@
     "prettify": "prettier --cache --color --no-error-on-unmatched-pattern --write \"**/{.*/,}*.{java}\" \"!**/test{-,/}fixtures/**\" || true",
     "test": "yarn lint"
   },
-  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@tsconfig/node-lts": "24.0.0",
@@ -62,7 +64,5 @@
     "eslint-plugin-unused-imports": ">=4",
     "globals": ">=16"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "prettier": "@willbooster/prettier-config"
 }

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -2,21 +2,20 @@
   "name": "@willbooster/eslint-config-js",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for JavaScript projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-js"
   },
-  "files": [
-    "eslint.config.js"
-  ],
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "type": "module",
   "main": "eslint.config.js",
-  "publishConfig": {
-    "access": "public"
-  },
+  "types": "eslint.config.d.ts",
+  "files": [
+    "eslint.config.d.ts",
+    "eslint.config.js"
+  ],
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -28,6 +27,7 @@
     "prettify": "prettier --cache --color --no-error-on-unmatched-pattern --write \"**/{.*/,}*.{java}\" \"!**/test{-,/}fixtures/**\" || true",
     "test": "yarn lint"
   },
+  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@tsconfig/node-lts": "24.0.0",
@@ -62,5 +62,7 @@
     "eslint-plugin-unused-imports": ">=4",
     "globals": ">=16"
   },
-  "prettier": "@willbooster/prettier-config"
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/eslint-config-next/eslint.config.d.ts
+++ b/packages/eslint-config-next/eslint.config.d.ts
@@ -1,0 +1,5 @@
+import type { Linter } from 'eslint';
+
+declare const config: Linter.Config[];
+
+export default config;

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -2,20 +2,23 @@
   "name": "@willbooster/eslint-config-next",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for Next.js projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-next"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -28,7 +31,6 @@
     "test": "yarn lint",
     "typecheck": "tsgo --noEmit"
   },
-  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint-react/eslint-plugin": "4.2.3",
     "@eslint/eslintrc": "3.3.5",
@@ -84,7 +86,5 @@
     "typescript": ">=5",
     "typescript-eslint": ">=8"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "prettier": "@willbooster/prettier-config"
 }

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -2,21 +2,20 @@
   "name": "@willbooster/eslint-config-next",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for Next.js projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-next"
   },
-  "files": [
-    "eslint.config.js"
-  ],
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "type": "module",
   "main": "eslint.config.js",
-  "publishConfig": {
-    "access": "public"
-  },
+  "types": "eslint.config.d.ts",
+  "files": [
+    "eslint.config.d.ts",
+    "eslint.config.js"
+  ],
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -29,6 +28,7 @@
     "test": "yarn lint",
     "typecheck": "tsgo --noEmit"
   },
+  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint-react/eslint-plugin": "4.2.3",
     "@eslint/eslintrc": "3.3.5",
@@ -84,5 +84,7 @@
     "typescript": ">=5",
     "typescript-eslint": ">=8"
   },
-  "prettier": "@willbooster/prettier-config"
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/eslint-config-ts-react/eslint.config.d.ts
+++ b/packages/eslint-config-ts-react/eslint.config.d.ts
@@ -1,0 +1,5 @@
+import type { Linter } from 'eslint';
+
+declare const config: Linter.Config[];
+
+export default config;

--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -2,21 +2,20 @@
   "name": "@willbooster/eslint-config-ts-react",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for TypeScript React projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-ts-react"
   },
-  "files": [
-    "eslint.config.js"
-  ],
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "type": "module",
   "main": "eslint.config.js",
-  "publishConfig": {
-    "access": "public"
-  },
+  "types": "eslint.config.d.ts",
+  "files": [
+    "eslint.config.d.ts",
+    "eslint.config.js"
+  ],
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -29,6 +28,7 @@
     "test": "yarn lint",
     "typecheck": "tsgo --noEmit"
   },
+  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint-react/eslint-plugin": "4.2.3",
     "@eslint/js": "10.0.1",
@@ -81,5 +81,7 @@
     "typescript": ">=5",
     "typescript-eslint": ">=8"
   },
-  "prettier": "@willbooster/prettier-config"
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -2,20 +2,23 @@
   "name": "@willbooster/eslint-config-ts-react",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for TypeScript React projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-ts-react"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -28,7 +31,6 @@
     "test": "yarn lint",
     "typecheck": "tsgo --noEmit"
   },
-  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint-react/eslint-plugin": "4.2.3",
     "@eslint/js": "10.0.1",
@@ -81,7 +83,5 @@
     "typescript": ">=5",
     "typescript-eslint": ">=8"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "prettier": "@willbooster/prettier-config"
 }

--- a/packages/eslint-config-ts/eslint.config.d.ts
+++ b/packages/eslint-config-ts/eslint.config.d.ts
@@ -1,0 +1,5 @@
+import type { Linter } from 'eslint';
+
+declare const config: Linter.Config[];
+
+export default config;

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -2,20 +2,23 @@
   "name": "@willbooster/eslint-config-ts",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for TypeScript projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-ts"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -28,7 +31,6 @@
     "test": "yarn lint",
     "typecheck": "tsgo --noEmit"
   },
-  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@tsconfig/node-lts": "24.0.0",
@@ -73,7 +75,5 @@
     "typescript": ">=5",
     "typescript-eslint": ">=8"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "prettier": "@willbooster/prettier-config"
 }

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -2,21 +2,20 @@
   "name": "@willbooster/eslint-config-ts",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for TypeScript projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-ts"
   },
-  "files": [
-    "eslint.config.js"
-  ],
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "type": "module",
   "main": "eslint.config.js",
-  "publishConfig": {
-    "access": "public"
-  },
+  "types": "eslint.config.d.ts",
+  "files": [
+    "eslint.config.d.ts",
+    "eslint.config.js"
+  ],
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -29,6 +28,7 @@
     "test": "yarn lint",
     "typecheck": "tsgo --noEmit"
   },
+  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@tsconfig/node-lts": "24.0.0",
@@ -73,5 +73,7 @@
     "typescript": ">=5",
     "typescript-eslint": ">=8"
   },
-  "prettier": "@willbooster/prettier-config"
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/oxfmt-config/config.d.ts
+++ b/packages/oxfmt-config/config.d.ts
@@ -1,3 +1,5 @@
-declare const config: object;
+import type { OxfmtConfig } from 'oxfmt';
+
+declare const config: OxfmtConfig;
 
 export default config;

--- a/packages/oxlint-config/config.d.ts
+++ b/packages/oxlint-config/config.d.ts
@@ -1,3 +1,5 @@
-declare const config: object;
+import type { OxlintConfig } from 'oxlint';
+
+declare const config: OxlintConfig;
 
 export default config;


### PR DESCRIPTION
## Summary

- Type the Oxlint and Oxfmt shared config exports with their upstream config types instead of plain object.
- Add declaration files for the published ESLint flat config packages.
- Include the ESLint declaration files in package metadata so TypeScript consumers can resolve them.

## Testing

- yarn check-for-ai
- yarn typecheck