### PR TITLE
fix: support next and blitz route filenames

### DIFF
--- a/packages/oxlint-config/config.mjs
+++ b/packages/oxlint-config/config.mjs
@@ -282,12 +282,12 @@ const config = {
   overrides: [
     {
       files: [
-        '**/app/**/{global-error,not-found}.{js,jsx,ts,tsx}',
+        '**/app/**/{default,error,global-error,layout,loading,not-found,page,route,template}.{js,jsx,ts,tsx}',
         '**/instrumentation-client.{js,jsx,ts,tsx}',
-        '**/pages/{_app,_document,_error,404,500}.{js,jsx,ts,tsx}',
+        '**/pages/**/*.{js,jsx,ts,tsx}',
       ],
       rules: {
-        // These filenames are reserved by Next.js and cannot be renamed to camelCase or PascalCase.
+        // Next.js and Blitz.js route filenames are part of public routing semantics.
         'unicorn/filename-case': 'off',
       },
     },


### PR DESCRIPTION
## Summary

- Broaden the oxlint filename-case override to cover Next.js App Router convention files.
- Disable filename-case for Pages Router and Blitz page route files, where file names define public routes.

## Why

Route filenames can intentionally use kebab-case, numeric names, underscores, or framework-reserved names. Enforcing camelCase/PascalCase there can require URL-breaking renames.

## Testing

- `yarn check-for-ai`
- pre-push `check.sh` hook