### PR TITLE
fix: ignore drizzle commit prereleases

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -205,6 +205,12 @@
       ignoreUnstable: false,
     },
     {
+      description: 'Ignore Drizzle commit-suffixed prereleases that SemVer can sort after beta releases',
+      matchDatasources: ['npm'],
+      matchPackageNames: ['drizzle-kit', 'drizzle-orm'],
+      allowedVersions: '/^\\d+\\.\\d+\\.\\d+(?:-[a-z]+\\.\\d+)?$/',
+    },
+    {
       matchPackageNames: ['eslint', '@types/eslint'],
       enabled: false,
     },


### PR DESCRIPTION
## Summary

- Add a Renovate package rule for `drizzle-kit` and `drizzle-orm`.
- Restrict allowed npm versions for those packages to normal releases and simple prereleases like `1.0.0-beta.20`.
- Exclude commit-suffixed prereleases like `1.0.0-beta.9-e89174b`, which SemVer can sort after numeric beta releases.

## Why

- Renovate proposed `1.0.0-beta.20` to `1.0.0-beta.9-e89174b` as a patch update.
- Filtering these commit-suffixed prereleases prevents wrong downgrade-looking updates while preserving normal Drizzle prerelease updates.

## Testing

- `yarn check-for-ai`
- pre-push hook check
