### PR TITLE
fix: exclude package json from oxfmt

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectTasksOptions">
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -22,7 +22,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -42,7 +42,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -62,7 +62,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -82,7 +82,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -102,7 +102,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -122,7 +122,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -142,7 +142,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -162,7 +162,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -182,7 +182,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -202,7 +202,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -222,7 +222,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -242,7 +242,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -262,7 +262,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -282,7 +282,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -302,7 +302,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -322,7 +322,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -342,7 +342,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -362,7 +362,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -382,7 +382,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -402,7 +402,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -422,7 +422,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -442,7 +442,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -462,7 +462,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -482,7 +482,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -502,7 +502,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
@@ -522,7 +522,7 @@
       <envs />
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $FilePathRelativeToProjectRoot$" />
+      <option name="arguments" value="node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json $FilePathRelativeToProjectRoot$" />
       <option name="checkSyntaxErrors" value="false" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,7 +16,7 @@ pre-commit:
       run: |-
         # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
         oxlint_files="$(printf '%s\n' {staged_files} | grep -E '(\.astro$|\.cjs$|\.cts$|\.js$|\.jsx$|\.mjs$|\.mts$|\.svelte$|\.ts$|\.tsx$|\.vue$)' || true)"
-        oxfmt_files="$(printf '%s\n' {staged_files} | grep -E '(\.astro$|\.cjs$|\.css$|\.cts$|\.gql$|\.graphql$|\.hbs$|\.htm$|\.html$|\.js$|\.json$|\.json5$|\.jsonc$|\.jsx$|\.less$|\.md$|\.mdx$|\.mjs$|\.mts$|\.scss$|\.svelte$|\.toml$|\.ts$|\.tsx$|\.vue$|\.yaml$|\.yml$)' || true)"
+        oxfmt_files="$(printf '%s\n' {staged_files} | grep -E '(\.astro$|\.cjs$|\.css$|\.cts$|\.gql$|\.graphql$|\.hbs$|\.htm$|\.html$|\.js$|\.json$|\.json5$|\.jsonc$|\.jsx$|\.less$|\.md$|\.mdx$|\.mjs$|\.mts$|\.scss$|\.svelte$|\.toml$|\.ts$|\.tsx$|\.vue$|\.yaml$|\.yml$)' | grep -v -E '(^|/)package\.json$' || true)"
         prettier_files="$(printf '%s\n' {staged_files} | grep -E '(\.java$)' || true)"
         package_json_files="$(printf '%s\n' {staged_files} | grep -E '(^|/)package\.json$' || true)"
 
@@ -24,7 +24,7 @@ pre-commit:
 
 
         if [ -n "$oxfmt_files" ]; then
-          node node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern $oxfmt_files
+          node node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern '!**/package.json' $oxfmt_files
         fi
 
         if [ -n "$prettier_files" ]; then

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code && yarn prettify && yarn workspaces foreach --all --parallel --verbose run format",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "yarn workspaces foreach --all --parallel --verbose run lint",
     "lint-fix": "yarn workspaces foreach --all --parallel --verbose run lint-fix",
     "prepare": "lefthook install || true",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "@willbooster/configs",
   "version": "0.0.0-semantically-released",
   "private": true,
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
   "workspaces": [
     "packages/*"
   ],
-  "type": "module",
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -26,6 +26,7 @@
     "test": "CI=1 FORCE_COLOR=3 yarn workspaces foreach --all --verbose run test",
     "typecheck": "yarn workspaces foreach --all --parallel --verbose run typecheck"
   },
+  "prettier": "@willbooster/prettier-config",
   "devDependencies": {
     "@anolilab/multi-semantic-release": "4.4.1",
     "@tsconfig/node-lts": "24.0.0",
@@ -46,6 +47,5 @@
     "semantic-release": "25.0.3",
     "sort-package-json": "3.6.1"
   },
-  "prettier": "@willbooster/prettier-config",
   "packageManager": "yarn@4.14.1"
 }

--- a/packages/eslint-config-js-react/package.json
+++ b/packages/eslint-config-js-react/package.json
@@ -21,7 +21,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "yarn lint"

--- a/packages/eslint-config-js-react/package.json
+++ b/packages/eslint-config-js-react/package.json
@@ -2,23 +2,20 @@
   "name": "@willbooster/eslint-config-js-react",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for JavaScript React projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-js-react"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -42,5 +39,8 @@
   },
   "peerDependencies": {
     "typescript": ">=5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -21,7 +21,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "yarn lint"

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -2,23 +2,20 @@
   "name": "@willbooster/eslint-config-js",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for JavaScript projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-js"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -38,5 +35,8 @@
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -21,7 +21,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "yarn lint",

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -2,23 +2,20 @@
   "name": "@willbooster/eslint-config-next",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for Next.js projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-next"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -49,5 +46,8 @@
   },
   "peerDependencies": {
     "typescript": ">=5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -21,7 +21,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "yarn lint",

--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -2,23 +2,20 @@
   "name": "@willbooster/eslint-config-ts-react",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for TypeScript React projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-ts-react"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -47,5 +44,8 @@
   },
   "peerDependencies": {
     "typescript": ">=5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -21,7 +21,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "yarn lint",

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -2,23 +2,20 @@
   "name": "@willbooster/eslint-config-ts",
   "version": "0.0.0-semantically-released",
   "description": "ESLint flat config for TypeScript projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/eslint-config-ts"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
+  "main": "eslint.config.js",
+  "types": "eslint.config.d.ts",
   "files": [
     "eslint.config.d.ts",
     "eslint.config.js"
   ],
-  "type": "module",
-  "main": "eslint.config.js",
-  "types": "eslint.config.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -45,5 +42,8 @@
   },
   "peerDependencies": {
     "typescript": ">=5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/oxfmt-config/config.mjs
+++ b/packages/oxfmt-config/config.mjs
@@ -24,6 +24,7 @@ const config = {
     '**/ios/**',
     '**/no-format/**',
     '**/node_modules/**',
+    '**/package.json',
     '**/temp/**',
     '**/tmp/**',
     '**/test-fixtures/**',

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -29,7 +29,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "typecheck": "tsgo --noEmit"

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -40,7 +40,6 @@
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "workspace:*",
-    "@willbooster/oxlint-config": "1.4.4",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.22.0",

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -2,31 +2,28 @@
   "name": "@willbooster/oxlint-config",
   "version": "0.0.0-semantically-released",
   "description": "Oxlint config for WillBooster projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/willbooster-configs.git",
     "directory": "packages/oxlint-config"
   },
-  "files": [
-    "config.d.ts",
-    "config.mjs",
-    "oxlint.config.ts",
-    "config.d.mts"
-  ],
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "type": "module",
-  "main": "config.mjs",
-  "types": "config.d.ts",
   "exports": {
     ".": {
       "types": "./config.d.ts",
       "default": "./config.mjs"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "main": "config.mjs",
+  "types": "config.d.ts",
+  "files": [
+    "config.d.ts",
+    "config.mjs",
+    "oxlint.config.ts",
+    "config.d.mts"
+  ],
   "scripts": {
     "check-all-for-ai": "yarn check-for-ai && yarn test",
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
@@ -52,5 +49,8 @@
   "peerDependencies": {
     "oxlint": ">=1.60.0",
     "oxlint-tsgolint": ">=0.18.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,7 @@
     "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
-    "format-code": "oxfmt --write --no-error-on-unmatched-pattern .",
+    "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "yarn lint",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,16 +2161,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@willbooster/oxlint-config@npm:1.4.4":
-  version: 1.4.4
-  resolution: "@willbooster/oxlint-config@npm:1.4.4"
-  peerDependencies:
-    oxlint: ">=1.60.0"
-    oxlint-tsgolint: ">=0.18.1"
-  checksum: 10c0/c3fcc9adf9e71df92b9292dbffb283ea689c27522576b8df1cd231033fd383ee24a2be1c6529cae2ecc1c9f7539b1c3d6dcd93cf83478de89adbebee89b772b2
-  languageName: node
-  linkType: hard
-
 "@willbooster/oxlint-config@workspace:*, @willbooster/oxlint-config@workspace:packages/oxlint-config":
   version: 0.0.0-use.local
   resolution: "@willbooster/oxlint-config@workspace:packages/oxlint-config"
@@ -2180,7 +2170,6 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "workspace:*"
-    "@willbooster/oxlint-config": "npm:1.4.4"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.22.0"


### PR DESCRIPTION
## Summary
- Add `**/package.json` to the shared oxfmt ignore patterns.
- Keep package manifests owned by `sort-package-json` instead of oxfmt.
- Apply the resulting `sort-package-json` ordering to manifests that were previously being rewritten by oxfmt.
- Run the updated `wbfy` against this repo and commit the generated package script, Lefthook, and IntelliJ watcher exclusions.

## Root Cause
`sort-package-json` and `oxfmt` both formatted `package.json`, but they disagree on key ordering. Ignoring `package.json` in the shared oxfmt config and generated settings makes `sort-package-json` the only formatter for package manifests.

## Verification
- `yarn cleanup`
- `yarn check-for-ai`
- pre-push `check` hook
- `yarn workspace @willbooster/wbfy start --skipDeps /Users/exkazuu/ghq/github.com/WillBooster/willbooster-configs`
