### PR TITLE
fix: remove config workspace release edges

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "@willbooster/prettier-config": "^10.4.0",
     "conventional-changelog-conventionalcommits": "9.3.1",
     "dotenv-cli": "11.0.0",

--- a/packages/eslint-config-js-react/package.json
+++ b/packages/eslint-config-js-react/package.json
@@ -29,8 +29,6 @@
   "devDependencies": {
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.22.0",

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -29,8 +29,6 @@
   "devDependencies": {
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.22.0",

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -34,8 +34,6 @@
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "eslint-config-next": "16.2.4",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",

--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -33,8 +33,6 @@
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.22.0",

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -32,8 +32,6 @@
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.22.0",

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -39,8 +39,6 @@
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.22.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,8 +22,6 @@
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
-    "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.5",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,8 +1861,6 @@ __metadata:
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     "@willbooster/prettier-config": "npm:^10.4.0"
     conventional-changelog-conventionalcommits: "npm:9.3.1"
     dotenv-cli: "npm:11.0.0"
@@ -1883,8 +1881,6 @@ __metadata:
   dependencies:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.22.0"
@@ -1901,8 +1897,6 @@ __metadata:
   dependencies:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.22.0"
@@ -1920,8 +1914,6 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@types/react": "npm:19.2.14"
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     eslint-config-next: "npm:16.2.4"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
@@ -1943,8 +1935,6 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@types/react": "npm:19.2.14"
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.22.0"
@@ -1964,8 +1954,6 @@ __metadata:
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.22.0"
@@ -1975,15 +1963,6 @@ __metadata:
     typescript: ">=5"
   languageName: unknown
   linkType: soft
-
-"@willbooster/oxfmt-config@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@willbooster/oxfmt-config@npm:1.2.2"
-  peerDependencies:
-    oxfmt: ">=0.42.0"
-  checksum: 10c0/41d08e269a644210e3f41bfe246e92d8b3f5432339a42eb9bf1611f3b6b0269362189183e1890ea7198803548ec8c04fd0e0d0d4aa75a0cf97e043fc16c59fd9
-  languageName: node
-  linkType: hard
 
 "@willbooster/oxfmt-config@workspace:packages/oxfmt-config":
   version: 0.0.0-use.local
@@ -1995,16 +1974,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@willbooster/oxlint-config@npm:1.4.5":
-  version: 1.4.5
-  resolution: "@willbooster/oxlint-config@npm:1.4.5"
-  peerDependencies:
-    oxlint: ">=1.60.0"
-    oxlint-tsgolint: ">=0.18.1"
-  checksum: 10c0/62522f944276ee5e24fda191f41d76da87d3d5df187e249c5d19b0e7c6e8eb11c61c744946d2170e3abb13754ed2962a642c95a9cb70c68821e4d1d1cfde19f9
-  languageName: node
-  linkType: hard
-
 "@willbooster/oxlint-config@workspace:packages/oxlint-config":
   version: 0.0.0-use.local
   resolution: "@willbooster/oxlint-config@workspace:packages/oxlint-config"
@@ -2013,8 +1982,6 @@ __metadata:
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.22.0"
@@ -2056,8 +2023,6 @@ __metadata:
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
-    "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.5"
     oxfmt: "npm:0.46.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.22.0"


### PR DESCRIPTION
## Summary

- Apply the updated `wbfy` output to remove managed `@willbooster/oxfmt-config` and `@willbooster/oxlint-config` dev dependencies from `willbooster-configs` package metadata.
- Update `yarn.lock` after removing those stale local workspace release edges.

## Why

- The release job at https://github.com/WillBooster/willbooster-configs/actions/runs/24968454304/job/73107187562 failed in `multi-semantic-release` with a dependency loop across the config packages.
- These dependencies were tool config edges, not package release edges, so they should not participate in release topological sorting.

## Testing

- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/willbooster-configs` from `~/ghq/github.com/WillBooster/shared/packages/wbfy`
- `yarn check-for-ai`
- `yarn multi-semantic-release --debug --dry-run`
- pre-push `check` hook

## Notes

- Depends on https://github.com/WillBooster/shared/pull/716 for the `wbfy` generator fix that produced this output.
