### PR TITLE
fix: make renovate internal checks filter explicit

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,8 @@
     'docker:pinDigests',
   ],
   dependencyDashboardAutoclose: true,
+  // This is Renovate's default, but keep it explicit so minimumReleaseAge gates branch updates.
+  internalChecksFilter: 'strict',
   packageRules: [
     {
       matchDatasources: ['npm', 'pypi'],


### PR DESCRIPTION
## Summary

- Set `internalChecksFilter: 'strict'` explicitly in the shared Renovate preset.
- Document that this is Renovate's current default, kept explicit so `minimumReleaseAge` gating remains clear.

## Verification

- `yarn check-for-ai`
