### PR TITLE
fix: remove oxlint config self dependency

### DIFF
--- a/AGENTS_EXTRA.md
+++ b/AGENTS_EXTRA.md
@@ -1,7 +1,3 @@
 # Lessons Learned
 
-- Avoid adding a workspace package as its own dependency, even in `devDependencies`.
-  `multi-semantic-release` uses package manifests to build a release order, so a self
-  dependency can create a topological loop and fail release jobs. When a package needs
-  to consume its own config during local checks, import the local source file instead
-  of the published package name.
+- Avoid adding a workspace package as its own dependency, even in `devDependencies`. `multi-semantic-release` uses package manifests to build a release order, so a self dependency can create a topological loop and fail release jobs. When a package needs to consume its own config during local checks, import the local source file instead of the published package name.

--- a/AGENTS_EXTRA.md
+++ b/AGENTS_EXTRA.md
@@ -1,0 +1,7 @@
+# Lessons Learned
+
+- Avoid adding a workspace package as its own dependency, even in `devDependencies`.
+  `multi-semantic-release` uses package manifests to build a release order, so a self
+  dependency can create a topological loop and fail release jobs. When a package needs
+  to consume its own config during local checks, import the local source file instead
+  of the published package name.

--- a/packages/oxlint-config/oxlint.config.ts
+++ b/packages/oxlint-config/oxlint.config.ts
@@ -1,5 +1,5 @@
 // wbfy:start oxlint-base
-import oxlintBaseConfig from '@willbooster/oxlint-config';
+import oxlintBaseConfig from './config.mjs';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -40,7 +40,6 @@
     "@types/node": "25.9.0",
     "@typescript/native-preview": "7.0.0-dev.20260518.1",
     "@willbooster/oxfmt-config": "1.2.2",
-    "@willbooster/oxlint-config": "1.4.6",
     "@willbooster/wb": "13.19.7",
     "oxfmt": "0.50.0",
     "oxlint": "1.65.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,7 +1440,6 @@ __metadata:
     "@types/node": "npm:25.9.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260518.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
-    "@willbooster/oxlint-config": "npm:1.4.6"
     "@willbooster/wb": "npm:13.19.7"
     oxfmt: "npm:0.50.0"
     oxlint: "npm:1.65.0"


### PR DESCRIPTION
## Summary

- Remove the `@willbooster/oxlint-config` package's self `devDependency`.
- Make `packages/oxlint-config/oxlint.config.ts` import local `./config.mjs` for self-linting.
- Add `AGENTS_EXTRA.md` with the release-topology lesson learned.

## Why

- The release job failed because `multi-semantic-release` detected a package graph loop involving `@willbooster/oxlint-config` and the ESLint config packages.
- The self dependency was unnecessary for local package checks; importing the local config preserves behavior without adding a release graph edge.

## Testing

- `yarn multi-semantic-release --dry-run --debug`
- `yarn verify`
- pre-push hook
