### PR TITLE
feat: let Renovate update vinext beta packages

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -207,6 +207,11 @@
       "ignoreUnstable": false,
     },
     {
+      "description": "Update vinext packages published only as beta prereleases",
+      "matchPackageNames": ["vinext", "/^@vinext\\//"],
+      "ignoreUnstable": false,
+    },
+    {
       "description": "Ignore Drizzle commit-suffixed prereleases that SemVer can sort after beta releases",
       "matchDatasources": ["npm"],
       "matchPackageNames": ["drizzle-kit", "drizzle-orm"],


### PR DESCRIPTION
## Why

`vinext` and `@vinext/*` (e.g. `@vinext/cloudflare`) are published only as beta prereleases — their `latest` dist-tag currently points to versions like `1.0.0-beta.2`. Renovate's default `ignoreUnstable: true` skips prerelease versions, so these packages never get update PRs.

## What

Add a `packageRule` with `ignoreUnstable: false` for `vinext` and `/^@vinext\//`, matching the existing pattern used for `yarn` and the react-compiler packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
