### PR TITLE
fix: stop the shared Renovate preset from extending itself

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>WillBooster/willbooster-configs:renovate.jsonc",
     "config:recommended",
     ":automergeDigest",
     ":automergeLinters",


### PR DESCRIPTION
## Problem

`renovate.jsonc` in this repository **is** the shared preset that every WillBooster / WillBoosterLab repository extends as `github>WillBooster/willbooster-configs:renovate.jsonc`. It listed itself in its own `extends` array.

That self-reference says nothing today (Renovate's recursion guard absorbs it), but it leaves the whole org one Renovate change away from failing to resolve the preset in every repository.

## Cause

`wbfy` injects the shared preset into every repository it manages — including this one, which is the preset. The corresponding guard (`isWillBoosterConfigs` → skip the injection) is being added in `WillBooster/shared`, so this will not come back.

## Note

This is separate from the `renovate.json5` → `renovate.jsonc` rename that broke Renovate in ~26 consumer repositories (WillBooster/shared#1038, WillBooster/reusable-workflows#462). Those are fixed by running `wbfy`, which already migrates the legacy preset reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
