### PR TITLE
feat: let Renovate update drizzle rc packages

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -211,9 +211,10 @@
       "ignoreUnstable": false,
     },
     {
-      "description": "Ignore Drizzle commit-suffixed prereleases that SemVer can sort after beta releases",
+      "description": "Update Drizzle packages published only as beta/rc prereleases, ignoring commit-suffixed ones that SemVer can sort after them",
       "matchDatasources": ["npm"],
-      "matchPackageNames": ["drizzle-kit", "drizzle-orm"],
+      "matchPackageNames": ["/^drizzle-/", "/^@drizzle-team\\//"],
+      "ignoreUnstable": false,
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(?:-[a-z]+\\.\\d+)?$/",
     },
     {


### PR DESCRIPTION
## Why

`drizzle-orm` / `drizzle-kit` の安定版は `0.45.x` / `0.31.x` のままで、実際に使いたい 1.0 系は `rc` プレリリースでのみ配布されている。既存ルールは commit ハッシュ付きプレリリースを除外するだけで `ignoreUnstable` が有効なままだったため、Renovate が rc を更新対象にしていなかった。

## What

- Drizzle 向けルールに `ignoreUnstable: false` を追加し、`1.0.0-beta.N` / `1.0.0-rc.N` を更新対象にした
- 対象を `drizzle-kit` / `drizzle-orm` から `/^drizzle-/` と `/^@drizzle-team\//` に広げ、drizzle 関連パッケージ全体をカバーした
- `allowedVersions` は据え置きで、`1.0.0-rc.4-5d5b77c` のような commit 付きプレリリースは引き続き除外される
