### PR TITLE
fix: remove invalid wildcard exclusion from Renovate pin rule

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -234,7 +234,7 @@
       "automergeStrategy": "squash",
     },
     {
-      "matchPackageNames": ["*", "!zod"],
+      "matchPackageNames": ["*"],
       "rangeStrategy": "pin",
     },
     {


### PR DESCRIPTION
## Why

`renovate-config-validator` fails on `renovate.jsonc`:

```
packageRules[24].matchPackageNames: Your input contains * or ** along with other patterns.
Please remove them, as * or ** matches all patterns.
```

## What

`matchPackageNames: ["*", "!zod"]` → `["*"]`.

Behavior is unchanged: the later `{"matchPackageNames": ["zod"], "rangeStrategy": "replace"}` rule already overrides the wildcard pin rule for `zod`, since Renovate applies `packageRules` in order.

Verified with `bunx --package renovate renovate-config-validator renovate.jsonc` → `Config validated successfully`.
