### PR TITLE
feat: validate the shared Renovate preset in CI and pre-commit

### DIFF
--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -1,0 +1,26 @@
+name: Validate Renovate config
+on:
+  pull_request:
+    paths:
+      - renovate.jsonc
+      - .github/workflows/renovate-config.yml
+  push:
+    branches:
+      - main
+    paths:
+      - renovate.jsonc
+      - .github/workflows/renovate-config.yml
+permissions:
+  contents: read
+concurrency:
+  group: renovate-config-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # This file is a shared preset consumed via `extends`, so `--no-global` validates it as a repo
+      # config instead of a self-hosted global config. The version is unpinned on purpose: the preset
+      # must stay valid for whichever Renovate version the hosted app currently runs.
+      - run: npx --yes --package renovate -- renovate-config-validator --strict --no-global renovate.jsonc

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -20,7 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Renovate requires a recent Node version, and npm silently installs an ancient Renovate that
+      # cannot even parse JSONC when the runner's Node is older, so install the pinned Node first.
+      - uses: jdx/mise-action@v4.2.0
+        with:
+          cache: true
       # This file is a shared preset consumed via `extends`, so `--no-global` validates it as a repo
-      # config instead of a self-hosted global config. The version is unpinned on purpose: the preset
-      # must stay valid for whichever Renovate version the hosted app currently runs.
-      - run: npx --yes --package renovate -- renovate-config-validator --strict --no-global renovate.jsonc
+      # config instead of a self-hosted global config. `@latest` is intentional: the preset must stay
+      # valid for whichever Renovate version the hosted app currently runs, and it also makes an
+      # incompatible Node version fail loudly instead of silently selecting an obsolete validator.
+      - run: npx --yes --package renovate@latest -- renovate-config-validator --strict --no-global renovate.jsonc

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,3 +29,6 @@ pre-commit:
           fi
         done
         exit "$failed"
+    - name: validate-renovate-config
+      glob: renovate.jsonc
+      run: npx --yes --package renovate -- renovate-config-validator --strict --no-global {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,4 +31,4 @@ pre-commit:
         exit "$failed"
     - name: validate-renovate-config
       glob: renovate.jsonc
-      run: npx --yes --package renovate -- renovate-config-validator --strict --no-global {staged_files}
+      run: npx --yes --package renovate@latest -- renovate-config-validator --strict --no-global {staged_files}


### PR DESCRIPTION
## Why

A broken rule in this repository's `renovate.jsonc` propagates to every WillBooster / WillBoosterLab repository the moment it lands on `main`, because each of them merely extends `github>WillBooster/willbooster-configs:renovate.jsonc`. #1058 fixed such a rule that had been shipping a Renovate configuration error.

Validating the downstream repositories instead would not help: `renovate-config-validator` does not resolve remote presets. A config extending a nonexistent preset validates successfully:

```jsonc
{ "extends": ["github>WillBooster/definitely-not-a-real-repo-xyz"] }  // → Config validated successfully
```

So this repository is the only place where the check has value.

## What

- `.github/workflows/renovate-config.yml`: runs `renovate-config-validator --strict --no-global renovate.jsonc` on PRs and `main` pushes that touch `renovate.jsonc`.
  - `--no-global` validates the file as a repo config (`INFO: Validating renovate.jsonc as repo config`) instead of the default self-hosted global config.
  - `jdx/mise-action` installs the repository's Node (24.18.0) first, and the validator is requested as `renovate@latest`. Both are required: npm resolves the newest *engine-compatible* Renovate, so on ubuntu-latest's default Node the first CI run silently installed `renovate@42.99.0`, which cannot even parse JSONC (`"message": "Unsupported file type"`, [run 29913572441](https://github.com/WillBooster/willbooster-configs/actions/runs/29913572441)). `@latest` also keeps the preset checked against whatever version the hosted Renovate app currently runs.
  - A separate workflow file rather than a step in `test.yml`: `test.yml` is a wbfy-generated caller of the reusable workflow.
- `lefthook.yml`: the same command as a `pre-commit` job scoped to `renovate.jsonc`, so the error surfaces before pushing. The corresponding wbfy generator change is in WillBooster/shared#1063 (it emits this job for this repository only); the file is updated here by hand so the hook works before the next `wbfy` run.

## Verification

- Reintroduced the #1058 defect locally and ran `lefthook run pre-commit` → the `validate-renovate-config` job failed with the expected `Your input contains * or **` error; the current file passes.
- After the Node fix, [run 29914593459](https://github.com/WillBooster/willbooster-configs/actions/runs/29914593459) printed `INFO: Config validated successfully against 1 file(s)`.
- The validator exits 1 on the broken config and 0 on the current one.
- `bun verify` passes.
