### PR TITLE
build: never let Renovate rewrite supply-chain security resolutions

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -186,6 +186,12 @@
       "enabled": true,
     },
     {
+      "description": "Supply-chain security pins must never be rewritten: clear-any-console >= 1.16.4 bundles the obfuscated command-code AI CLI, and http is aliased away from npm's security-holder package that the Takumi Guard proxy blocks (see WillBooster/survey-system#535)",
+      "matchDepTypes": ["overrides", "resolutions"],
+      "matchDepNames": ["clear-any-console", "http"],
+      "enabled": false,
+    },
+    {
       "groupName": "willbooster-config",
       "matchPackageNames": ["/^@willbooster/.*config/"],
     },


### PR DESCRIPTION
## Summary

プリセットの `{"matchDepTypes": ["overrides", "resolutions"], "enabled": true}` により、Renovate は各リポジトリの `resolutions` エントリも更新対象にしています。このままだと Blitz 系リポジトリ(survey-system / chofu-walking / literacy-test)に入れたサプライチェーン対策ピンが Renovate に書き戻されるため、**該当2エントリのみ**更新を無効化するルールを後段に追加します:

- `clear-any-console`: 1.16.4 以降は作者が難読化 AI CLI `command-code` を未使用依存として同梱(WillBooster/survey-system#535 で検出)。1.16.3 固定を維持する必要がある。
- `http`: `@blitzjs/auth` が宣言する npm security holder(`http@0.0.1-security`)を `npm:path@0.12.7` にエイリアスしたもの。Takumi Guard が 403 でブロックするため、エイリアスの書き換え・解除は CI を壊す。

## 設計判断

resolutions 全体の無効化は行いません: react / react-dom / react-is 等の resolutions は依存本体の更新と**同期して**更新される必要があり(この同期のために既存の enabled:true ルールが存在)、全体無効化すると依存とピンがズレて解決が壊れます。matchDepNames で対象2件だけを後段ルールで上書きします。

## Testing

- `renovate-config-validator renovate.jsonc` パス
- `bun run verify` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)