### PR TITLE
chore(renovate): automerge every update including major

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -2,12 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":automergeDigest",
-    ":automergeLinters",
-    ":automergeMinor",
     ":automergePr",
-    ":automergeTesters",
-    ":automergeTypes",
     ":maintainLockFilesWeekly",
     ":prImmediately",
     ":rebaseStalePrs",
@@ -16,6 +11,7 @@
     "docker:pinDigests",
   ],
   "description": "Default preset for use with WillBooster and WillBoosterLab repos",
+  "automerge": true,
   "dependencyDashboardAutoclose": true,
   "internalChecksFilter": "strict",
   "packageRules": [


### PR DESCRIPTION
Enable automerge for all Renovate PRs, including major version updates.

- Set top-level `"automerge": true`, so every update type (major included) automerges once its branch checks pass.
- Dropped the now-redundant `:automergeDigest`, `:automergeMinor`, `:automergeLinters`, `:automergeTesters`, and `:automergeTypes` presets; `:automergePr` is kept so merges happen via PR.
- The Docker digest rule keeps its `automergeType: "branch"` override.

Validated with `renovate-config-validator` (lefthook pre-commit hook) and `bun verify`.
