### PR TITLE
docs(renovate): correct clear-any-console clean-version note to 1.16.2

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -182,7 +182,7 @@
       "enabled": true,
     },
     {
-      "description": "Supply-chain security pins must never be rewritten: clear-any-console >= 1.16.4 bundles the obfuscated command-code AI CLI, and http is aliased away from npm's security-holder package that the Takumi Guard proxy blocks (see WillBooster/survey-system#535)",
+      "description": "Supply-chain security pins must never be rewritten: clear-any-console >= 1.16.3 adds the author's AI SDK langbase as an unused dependency (>= 1.16.4 also bundles the obfuscated command-code AI CLI), so 1.16.2 is the last clean release (see WillBooster/literacy-test#932); http is aliased away from npm's security-holder package that the Takumi Guard proxy blocks (see WillBooster/survey-system#535)",
       "matchDepTypes": ["overrides", "resolutions"],
       "matchDepNames": ["clear-any-console", "http"],
       "enabled": false,


### PR DESCRIPTION
## Customer Summary

- 動作の変更はありません。Renovate 設定内のセキュリティピン保護ルールの説明文(コメント)のみを最新の調査結果に合わせて修正しました。
- `clear-any-console` のピンが Renovate に書き換えられない挙動は従来どおりです。

## Technical Summary

- `renovate.jsonc` の supply-chain security ピン保護ルール(`clear-any-console` / `http` の `resolutions`・`overrides` 更新を無効化するルール)の `description` を更新。
- 「>= 1.16.4 が問題」という旧記述を、「>= 1.16.3 で作者の AI SDK `langbase` が未使用依存として混入(>= 1.16.4 では難読化された `command-code` AI CLI も同梱)、クリーンなのは 1.16.2 まで」に修正し、根拠として WillBooster/literacy-test#932 を参照。

## Why

- WillBooster/literacy-test#932 のマルチエージェントレビューで、問題の開始バージョンが 1.16.4 ではなく 1.16.3 であることが判明した(`npm view clear-any-console@1.16.3 dependencies` → `{ langbase: '*' }`)。
- ルール自体はバージョン非依存で機能しているが、古い記述を根拠に将来の判断を誤らないよう説明文のみを訂正する。

## Testing

- `bun verify`(型チェック・リント)通過。
- pre-commit フックの `validate-renovate-config`(renovate-config-validator)通過。
- CI(GitHub Actions)全ワークフロー成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
