### PR TITLE
feat: add opt-in Renovate Verdaccio preset

### DIFF
--- a/renovate-private-packages.jsonc
+++ b/renovate-private-packages.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Authenticate Renovate with the WillBooster private npm registry",
+  "hostRules": [
+    {
+      "hostType": "npm",
+      "matchHost": "https://verdaccio-production-e389.up.railway.app/",
+      "authType": "Basic",
+      "token": "{{ secrets.VerdaccioBasicAuth }}",
+    },
+  ],
+  "npmrc": "@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/",
+  "npmrcMerge": true,
+}

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -19,7 +19,7 @@
       "hostType": "npm",
       "matchHost": "https://verdaccio-production-e389.up.railway.app/",
       "authType": "Basic",
-      "token": "{{ secrets.VerdaccioReadonlyBasicAuth }}",
+      "token": "{{ secrets.VerdaccioBasicAuth }}",
     },
   ],
   "npmrc": "@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/",

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -14,6 +14,15 @@
   "automerge": true,
   "dependencyDashboardAutoclose": true,
   "internalChecksFilter": "strict",
+  "hostRules": [
+    {
+      "hostType": "npm",
+      "matchHost": "https://verdaccio-production-e389.up.railway.app/",
+      "authType": "Basic",
+      "token": "{{ secrets.VerdaccioReadonlyBasicAuth }}",
+    },
+  ],
+  "npmrc": "@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/",
   "packageRules": [
     {
       "matchDatasources": ["npm", "pypi"],

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -14,16 +14,6 @@
   "automerge": true,
   "dependencyDashboardAutoclose": true,
   "internalChecksFilter": "strict",
-  "hostRules": [
-    {
-      "hostType": "npm",
-      "matchHost": "https://verdaccio-production-e389.up.railway.app/",
-      "authType": "Basic",
-      "token": "{{ secrets.VerdaccioBasicAuth }}",
-    },
-  ],
-  "npmrc": "@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/",
-  "npmrcMerge": true,
   "packageRules": [
     {
       "matchDatasources": ["npm", "pypi"],

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -23,6 +23,7 @@
     },
   ],
   "npmrc": "@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/",
+  "npmrcMerge": true,
   "packageRules": [
     {
       "matchDatasources": ["npm", "pypi"],


### PR DESCRIPTION
## Customer Summary

- Adds a reusable, opt-in Renovate preset for repositories that consume `@willbooster-private/*` packages.
- Keeps the default public preset unchanged, so repositories outside WillBooster and WillBoosterLab continue running without Mend credentials.
- Uses the `VerdaccioBasicAuth` credential registered at Mend organization scope for WillBooster and WillBoosterLab.

## Technical Summary

- Adds `renovate-private-packages.jsonc` with the Verdaccio scope mapping, Basic npm host rule, and `npmrcMerge: true`.
- References the Mend secret placeholder `{{ secrets.VerdaccioBasicAuth }}` without committing any credential value.
- Leaves `renovate.jsonc` unchanged; consumers must explicitly extend the private-package preset.

## Why

- Renovate needs Basic authentication so its generated npm configuration uses `_auth`, which Bun consumes, rather than `_authToken`.
- The credential cannot be placed in the default public preset because missing Mend secrets abort Renovate for consumers outside the configured organizations.
- Renovate 44.3.2 does not pass preset `npmrc` scope mappings into Bun artifact updates, so a follow-up wbfy change is still required to provide the credential-free scope mapping where `bun install` reads it.

## Testing

- `bun verify`
- `bunx --yes --package renovate@44.3.2 -- renovate-config-validator --strict --no-global renovate.jsonc renovate-private-packages.jsonc`
- Confirmed the default `renovate.jsonc` is unchanged from `origin/main`.
- Confirmed `VerdaccioBasicAuth` exists as a Mend organization secret for WillBooster and WillBoosterLab.
